### PR TITLE
Data-driven rendering: eliminate hardcoded routine values

### DIFF
--- a/src/domain/reflow.ts
+++ b/src/domain/reflow.ts
@@ -16,6 +16,8 @@ export function computeUpcoming(
   maxSessions: number
 ): UpcomingItem[] {
   const routineMap = new Map(routines.map((r) => [r.id, r]));
+  const dailyRoutine = routines.find((r) => r.isDaily);
+  const spacerTitle = dailyRoutine?.title ?? "Rest";
 
   // Build the template rhythm: which day indices are spacers vs routines
   const templateRhythm: Array<{ type: "routine" | "spacer"; routineId?: string }> = [];
@@ -52,7 +54,7 @@ export function computeUpcoming(
     const rhythmSlot = templateRhythm[rhythmIndex % templateRhythm.length];
 
     if (rhythmSlot.type === "spacer") {
-      result.push({ type: "spacer", title: "CARs only" });
+      result.push({ type: "spacer", title: spacerTitle });
     } else {
       const item = pendingItems[pendingIdx];
       const routine = routineMap.get(item.routine_id);

--- a/src/fragments/today.ts
+++ b/src/fragments/today.ts
@@ -16,15 +16,18 @@ export function carsCard(routine: Routine, hevyRoutineId?: string): string {
 
   const hevyButton = hevyRoutineId
     ? `<a href="https://hevy.com/routine/${escapeAttr(hevyRoutineId)}" target="_blank" class="btn btn-blue">Open in Hevy</a>`
-    : `<button class="btn btn-blue" data-on:click="@post('/api/push-hevy/daily')">Push to Hevy</button>`;
+    : `<button class="btn btn-blue" data-on:click="@post('/api/push-hevy/${escapeAttr(routine.id)}')">Push to Hevy</button>`;
+
+  const labelColor = escapeAttr(routine.color ?? "var(--green)");
+  const label = escapeHtml(routine.isDaily ? "Daily" : routine.title);
 
   return `<div class="card">
-  <div class="card-label" style="color: var(--green)">Daily</div>
+  <div class="card-label" style="color: ${labelColor}">${label}</div>
   <div class="card-title">${escapeHtml(routine.title)}</div>
   <div class="card-subtitle">${escapeHtml(subtitle)}</div>
   <div style="display:flex; gap:8px; margin-top:14px">
     ${hevyButton}
-    <a href="/routine/daily" class="btn btn-ghost">Details</a>
+    <a href="/routine/${encodeURIComponent(routine.id)}" class="btn btn-ghost">Details</a>
   </div>
 </div>`;
 }

--- a/test/domain/reflow.test.ts
+++ b/test/domain/reflow.test.ts
@@ -35,8 +35,37 @@ describe("computeUpcoming", () => {
     const upcoming = computeUpcoming(pending, template, routines, 5);
     const types = upcoming.map((u) => u.type);
     expect(types[0]).toBe("routine");   // b
-    expect(types[1]).toBe("spacer");    // CARs-only
+    expect(types[1]).toBe("spacer");    // daily-only day
     expect(types[2]).toBe("routine");   // c
+  });
+
+  it("derives spacer title from the daily routine's title", () => {
+    const pending: QueueItemRow[] = [
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null },
+      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null },
+    ];
+
+    const upcoming = computeUpcoming(pending, template, routines, 5);
+    const spacer = upcoming.find((u) => u.type === "spacer");
+    // routines[0] has isDaily: true and title: "CARs"
+    expect(spacer?.title).toBe("CARs");
+  });
+
+  it("falls back to 'Rest' for spacer title when no daily routine exists", () => {
+    const noDaily: Routine[] = [
+      { id: "a", title: "Routine A", exercises: [] },
+      { id: "b", title: "Routine B", exercises: [] },
+      { id: "c", title: "Routine C", exercises: [] },
+      { id: "recovery", title: "Recovery", exercises: [] },
+    ];
+    const pending: QueueItemRow[] = [
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null },
+      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null },
+    ];
+
+    const upcoming = computeUpcoming(pending, template, noDaily, 5);
+    const spacer = upcoming.find((u) => u.type === "spacer");
+    expect(spacer?.title).toBe("Rest");
   });
 
   it("limits to requested count of main sessions", () => {


### PR DESCRIPTION
## Summary
- Replace hardcoded `"daily"` string in push URL, details link, label text, and color with `routine.id`, `routine.color`, and `routine.isDaily` in `carsCard`
- Derive spacer title in `computeUpcoming` from daily routine's title instead of hardcoded `"CARs only"`
- Add 2 new tests for spacer title derivation (with and without daily routine)

## Test plan
- [x] All 47 tests pass (`npm run test`)
- [ ] Verify Today page renders correct colors/labels via `wrangler dev`
- [ ] Grep `src/` for remaining `"daily"` and `"Daily"` — confirm only defaults

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)