### PR TITLE
Workout detail display with sets/reps/weights from Hevy

### DIFF
--- a/migrations/0005_workout_data.sql
+++ b/migrations/0005_workout_data.sql
@@ -1,0 +1,1 @@
+ALTER TABLE queue_items ADD COLUMN hevy_workout_data TEXT;

--- a/src/domain/workout-compare.ts
+++ b/src/domain/workout-compare.ts
@@ -1,0 +1,86 @@
+// ──────────────────────────────────────────────────────────────────
+// workout-compare — compare actual Hevy workout data vs prescribed
+// ──────────────────────────────────────────────────────────────────
+
+import type { RoutineExercise } from "../types";
+
+export interface ActualSet {
+  type: "normal" | "warmup" | "dropset" | "failure";
+  reps?: number;
+  weight_kg?: number;
+  duration_seconds?: number;
+  rpe?: number;
+}
+
+export interface ExerciseComparison {
+  exerciseTitle: string;
+  status: "matched" | "extra" | "missing";
+  /** e.g. "3×8" from the routine prescription */
+  prescribedSets?: string;
+  actualSets: ActualSet[];
+}
+
+export interface HevyWorkoutExercise {
+  exercise_template_id: string;
+  title: string;
+  sets: ActualSet[];
+}
+
+/**
+ * Compare actual workout data from Hevy with prescribed sets from the program routine.
+ *
+ * @param actualExercises - parsed from hevy_workout_data JSON (Hevy exercise format)
+ * @param prescribedExercises - from the program routine's exercises array
+ * @param templateMap - maps hevy_template_id → program_template_id
+ */
+export function compareWorkout(
+  actualExercises: HevyWorkoutExercise[],
+  prescribedExercises: RoutineExercise[],
+  templateMap: Map<string, string>
+): ExerciseComparison[] {
+  // Build reverse map: program_template_id → prescribed exercise
+  const prescribedByProgramId = new Map<string, RoutineExercise>(
+    prescribedExercises.map((e) => [e.exerciseTemplateId, e])
+  );
+
+  const result: ExerciseComparison[] = [];
+  const matchedProgramIds = new Set<string>();
+
+  // Process each actual exercise
+  for (const actual of actualExercises) {
+    const programTemplateId = templateMap.get(actual.exercise_template_id);
+    const prescribed = programTemplateId
+      ? prescribedByProgramId.get(programTemplateId)
+      : undefined;
+
+    if (prescribed && programTemplateId) {
+      matchedProgramIds.add(programTemplateId);
+      result.push({
+        exerciseTitle: actual.title,
+        status: "matched",
+        prescribedSets: prescribed.sets,
+        actualSets: actual.sets,
+      });
+    } else {
+      result.push({
+        exerciseTitle: actual.title,
+        status: "extra",
+        actualSets: actual.sets,
+      });
+    }
+  }
+
+  // Add any prescribed exercises that were not performed
+  for (const prescribed of prescribedExercises) {
+    if (!matchedProgramIds.has(prescribed.exerciseTemplateId)) {
+      result.push({
+        exerciseTitle: prescribed.exerciseTemplateId,
+        status: "missing",
+        prescribedSets: prescribed.sets,
+        actualSets: [],
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/fragments/today.ts
+++ b/src/fragments/today.ts
@@ -2,8 +2,9 @@
 // Today page fragments — CARs card, hero routine, completed, upcoming
 // ──────────────────────────────────────────────────────────────────
 
-import type { Routine, QueueItemRow } from "../types";
+import type { Routine, QueueItemRow, RoutineExercise } from "../types";
 import type { UpcomingItem } from "../domain/reflow";
+import type { HevyWorkoutExercise, ActualSet } from "../domain/workout-compare";
 import { escapeHtml, escapeAttr, truncate } from "../utils/html";
 
 /**
@@ -56,21 +57,108 @@ export function heroRoutineCard(routine: Routine, queueItem: QueueItemRow): stri
 </div>`;
 }
 
+// ──────────────────────────────────────────────────────────────────
+// Workout data helpers
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Format a single set as a compact string, e.g. "50kg × 8", "45 sec", "8 reps".
+ */
+function formatSet(set: ActualSet): string {
+  if (set.duration_seconds != null) {
+    const secs = set.duration_seconds;
+    if (secs >= 60 && secs % 60 === 0) {
+      return `${secs / 60} min`;
+    }
+    return `${secs} sec`;
+  }
+  if (set.weight_kg != null && set.weight_kg > 0 && set.reps != null) {
+    return `${set.weight_kg}kg \u00d7 ${set.reps}`;
+  }
+  if (set.reps != null) {
+    return `${set.reps} reps`;
+  }
+  return "1 set";
+}
+
+/**
+ * Render one exercise's sets as a compact inline string.
+ * e.g. "45kg × 8, 50kg × 6, 50kg × 5"
+ */
+function formatSetsInline(sets: ActualSet[]): string {
+  if (sets.length === 0) return "";
+  return sets.map(formatSet).join(", ");
+}
+
+/**
+ * Parse hevy_workout_data JSON, returning an empty array on failure.
+ */
+function parseWorkoutData(raw: string | null): HevyWorkoutExercise[] {
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as HevyWorkoutExercise[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Render the workout detail block for a completed item.
+ * Returns an empty string if there is no stored workout data.
+ */
+function workoutDetailBlock(hevy_workout_data: string | null): string {
+  const exercises = parseWorkoutData(hevy_workout_data);
+  if (exercises.length === 0) return "";
+
+  const totalSets = exercises.reduce((sum, e) => sum + e.sets.length, 0);
+  const summary = `${exercises.length} exercise${exercises.length !== 1 ? "s" : ""}, ${totalSets} set${totalSets !== 1 ? "s" : ""}`;
+
+  const exerciseRows = exercises
+    .map((ex) => {
+      const setsLine = formatSetsInline(ex.sets);
+      return `<div class="workout-exercise">
+  <span class="workout-ex-name">${escapeHtml(ex.title)}</span>
+  ${setsLine ? `<span class="workout-ex-sets">${escapeHtml(setsLine)}</span>` : ""}
+</div>`;
+    })
+    .join("\n");
+
+  return `<details class="workout-details">
+  <summary class="workout-summary">${escapeHtml(summary)}</summary>
+  <div class="workout-exercises">
+${exerciseRows}
+  </div>
+</details>`;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Completed section
+// ──────────────────────────────────────────────────────────────────
+
+export interface CompletedItemData {
+  title: string;
+  hevy_workout_data: string | null;
+  prescribedExercises: RoutineExercise[];
+}
+
 /**
  * Completed section — items finished earlier today.
- * Shown with strikethrough text and a green checkmark.
+ * Shown with strikethrough text, a green checkmark, and expandable workout details.
  */
-export function completedSection(items: Array<{ title: string }>): string {
+export function completedSection(items: CompletedItemData[]): string {
   if (items.length === 0) return "";
 
   const rows = items
-    .map(
-      (item) =>
-        `<div class="completed-item">
-  <span class="completed-title">${escapeHtml(item.title)}</span>
-  <span class="completed-check">&#10003;</span>
-</div>`
-    )
+    .map((item) => {
+      const detail = workoutDetailBlock(item.hevy_workout_data);
+      return `<div class="completed-item">
+  <div class="completed-header">
+    <span class="completed-title">${escapeHtml(item.title)}</span>
+    <span class="completed-check">&#10003;</span>
+  </div>
+  ${detail}
+</div>`;
+    })
     .join("\n");
 
   return `<div class="section-header">Completed Today</div>
@@ -123,4 +211,3 @@ export function upcomingSection(items: UpcomingItem[]): string {
 ${rows}
 </div>`;
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,9 +344,11 @@ async function handleTodaySSE(env: Env, userId: string, tz?: string): Promise<Re
   const completed = getCompletedRoutines(items, today);
   const completedData = completed.map((item) => ({
     title: routineMap.get(item.routine_id)?.title ?? item.routine_id,
+    hevy_workout_data: item.hevy_workout_data,
+    prescribedExercises: routineMap.get(item.routine_id)?.exercises ?? [],
   }));
   if (dailyDoneToday) {
-    completedData.unshift({ title: dailyRoutine.title });
+    completedData.unshift({ title: dailyRoutine.title, hevy_workout_data: null, prescribedExercises: [] });
   }
   if (completedData.length > 0) {
     fragments.push(
@@ -851,16 +853,19 @@ async function handlePull(env: Env, userId: string, tz?: string): Promise<Respon
 
     // Build workout ID → local date map for accurate completion dates
     const workoutDateMap = new Map<string, string>();
+    const workoutExercisesMap = new Map<string, string>();
     for (const w of newWorkouts) {
       const d = tz
         ? new Date(w.start_time).toLocaleDateString("en-CA", { timeZone: tz })
         : w.start_time.slice(0, 10);
       workoutDateMap.set(w.id, d);
+      workoutExercisesMap.set(w.id, JSON.stringify(w.exercises));
     }
 
     for (const match of matches) {
       const completedDate = workoutDateMap.get(match.workoutId) ?? todayString(tz);
-      await markQueueItemCompleted(env.DB, match.queueItemId, completedDate, match.workoutId);
+      const workoutData = workoutExercisesMap.get(match.workoutId);
+      await markQueueItemCompleted(env.DB, match.queueItemId, completedDate, match.workoutId, workoutData);
     }
 
     // Check for daily routine completion (use workout date, not sync date)

--- a/src/storage/queries.ts
+++ b/src/storage/queries.ts
@@ -46,13 +46,14 @@ export async function markQueueItemCompleted(
   db: D1Database,
   itemId: number,
   completedDate: string,
-  hevyWorkoutId?: string
+  hevyWorkoutId?: string,
+  workoutData?: string
 ): Promise<void> {
   await db
     .prepare(
-      "UPDATE queue_items SET status = 'completed', completed_date = ?, hevy_workout_id = ? WHERE id = ?"
+      "UPDATE queue_items SET status = 'completed', completed_date = ?, hevy_workout_id = ?, hevy_workout_data = ? WHERE id = ?"
     )
-    .bind(completedDate, hevyWorkoutId ?? null, itemId)
+    .bind(completedDate, hevyWorkoutId ?? null, workoutData ?? null, itemId)
     .run();
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface QueueItemRow {
   readonly completed_date: string | null;
   readonly hevy_routine_id: string | null;
   readonly hevy_workout_id: string | null;
+  readonly hevy_workout_data: string | null;
 }
 
 export interface ExerciseTemplateMappingRow {

--- a/test/domain/workout-compare.test.ts
+++ b/test/domain/workout-compare.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { compareWorkout } from "../../src/domain/workout-compare";
+import type { HevyWorkoutExercise } from "../../src/domain/workout-compare";
+import type { RoutineExercise } from "../../src/types";
+
+// helpers
+function makeActual(
+  templateId: string,
+  title: string,
+  sets: HevyWorkoutExercise["sets"]
+): HevyWorkoutExercise {
+  return { exercise_template_id: templateId, title, sets };
+}
+
+function makePresecribed(templateId: string, sets = "3×8"): RoutineExercise {
+  return { exerciseTemplateId: templateId, sets };
+}
+
+describe("compareWorkout", () => {
+  it("marks all exercises as matched when actual and prescribed align", () => {
+    const templateMap = new Map([
+      ["hevy-1", "prog-squat"],
+      ["hevy-2", "prog-rdl"],
+    ]);
+    const actual: HevyWorkoutExercise[] = [
+      makeActual("hevy-1", "Squat", [{ type: "normal", reps: 8, weight_kg: 100 }]),
+      makeActual("hevy-2", "Romanian Deadlift", [{ type: "normal", reps: 10, weight_kg: 70 }]),
+    ];
+    const prescribed: RoutineExercise[] = [
+      makePresecribed("prog-squat", "3×8"),
+      makePresecribed("prog-rdl", "3×10"),
+    ];
+
+    const result = compareWorkout(actual, prescribed, templateMap);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].status).toBe("matched");
+    expect(result[0].exerciseTitle).toBe("Squat");
+    expect(result[0].prescribedSets).toBe("3×8");
+    expect(result[0].actualSets).toHaveLength(1);
+    expect(result[1].status).toBe("matched");
+    expect(result[1].exerciseTitle).toBe("Romanian Deadlift");
+  });
+
+  it("marks extra exercises when user adds an exercise not in the program", () => {
+    const templateMap = new Map([["hevy-1", "prog-squat"]]);
+    const actual: HevyWorkoutExercise[] = [
+      makeActual("hevy-1", "Squat", [{ type: "normal", reps: 8, weight_kg: 100 }]),
+      makeActual("hevy-99", "Bench Press", [{ type: "normal", reps: 10, weight_kg: 80 }]),
+    ];
+    const prescribed: RoutineExercise[] = [makePresecribed("prog-squat", "3×8")];
+
+    const result = compareWorkout(actual, prescribed, templateMap);
+
+    expect(result).toHaveLength(2);
+    const extra = result.find((r) => r.status === "extra");
+    expect(extra).toBeDefined();
+    expect(extra!.exerciseTitle).toBe("Bench Press");
+    expect(extra!.prescribedSets).toBeUndefined();
+    expect(extra!.actualSets).toHaveLength(1);
+  });
+
+  it("marks missing exercises when user skips a prescribed exercise", () => {
+    const templateMap = new Map([["hevy-1", "prog-squat"]]);
+    const actual: HevyWorkoutExercise[] = [
+      makeActual("hevy-1", "Squat", [{ type: "normal", reps: 8, weight_kg: 100 }]),
+      // prog-rdl was prescribed but not performed
+    ];
+    const prescribed: RoutineExercise[] = [
+      makePresecribed("prog-squat", "3×8"),
+      makePresecribed("prog-rdl", "3×10"),
+    ];
+
+    const result = compareWorkout(actual, prescribed, templateMap);
+
+    expect(result).toHaveLength(2);
+    const missing = result.find((r) => r.status === "missing");
+    expect(missing).toBeDefined();
+    expect(missing!.exerciseTitle).toBe("prog-rdl");
+    expect(missing!.prescribedSets).toBe("3×10");
+    expect(missing!.actualSets).toHaveLength(0);
+  });
+
+  it("returns empty array when both actual and prescribed are empty", () => {
+    const result = compareWorkout([], [], new Map());
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles null-equivalent empty workout data (no actual exercises)", () => {
+    const templateMap = new Map([["hevy-1", "prog-squat"]]);
+    const actual: HevyWorkoutExercise[] = [];
+    const prescribed: RoutineExercise[] = [makePresecribed("prog-squat", "3×8")];
+
+    const result = compareWorkout(actual, prescribed, templateMap);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("missing");
+    expect(result[0].actualSets).toHaveLength(0);
+  });
+
+  it("handles duration-type sets in actual exercises", () => {
+    const templateMap = new Map([["hevy-1", "prog-dead-hang"]]);
+    const actual: HevyWorkoutExercise[] = [
+      makeActual("hevy-1", "Dead Hang", [
+        { type: "normal", duration_seconds: 30 },
+        { type: "normal", duration_seconds: 30 },
+        { type: "normal", duration_seconds: 25 },
+      ]),
+    ];
+    const prescribed: RoutineExercise[] = [makePresecribed("prog-dead-hang", "3×30 sec")];
+
+    const result = compareWorkout(actual, prescribed, templateMap);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("matched");
+    expect(result[0].actualSets).toHaveLength(3);
+    expect(result[0].actualSets[0].duration_seconds).toBe(30);
+  });
+
+  it("handles mixed extra and missing exercises together", () => {
+    // Prescribed: A and B. Actual: A and C (C is extra, B is missing).
+    const templateMap = new Map([
+      ["hevy-a", "prog-a"],
+      ["hevy-b", "prog-b"],
+    ]);
+    const actual: HevyWorkoutExercise[] = [
+      makeActual("hevy-a", "Exercise A", [{ type: "normal", reps: 5 }]),
+      makeActual("hevy-c", "Exercise C (extra)", [{ type: "normal", reps: 8 }]),
+    ];
+    const prescribed: RoutineExercise[] = [
+      makePresecribed("prog-a", "3×5"),
+      makePresecribed("prog-b", "3×8"),
+    ];
+
+    const result = compareWorkout(actual, prescribed, templateMap);
+
+    expect(result).toHaveLength(3);
+    const statuses = result.map((r) => r.status);
+    expect(statuses).toContain("matched");
+    expect(statuses).toContain("extra");
+    expect(statuses).toContain("missing");
+  });
+});


### PR DESCRIPTION
## Summary
- Store workout exercise data as JSON on completed queue items (new `hevy_workout_data` column)
- Display expandable workout details on Today page (exercise count, total sets, per-exercise breakdown)
- Add `compareWorkout` pure domain function for actual vs prescribed set comparison
- Migration: `0005_workout_data.sql`

## Test plan
- [x] All 54 tests pass (7 new for `compareWorkout`)
- [ ] Complete workout in Hevy → Sync → verify detail appears
- [ ] Verify manual completions (no workout data) render gracefully
- [ ] Apply migration locally and verify schema

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)