### PR TITLE
Program import/upload from JSON

### DIFF
--- a/src/fragments/program.ts
+++ b/src/fragments/program.ts
@@ -1,9 +1,9 @@
 // ──────────────────────────────────────────────────────────────────
 // Program page fragments — overview, progressions, routines,
-// foundations, resources, BODi
+// foundations, resources, BODi, import
 // ──────────────────────────────────────────────────────────────────
 
-import type { Program, Progression, Foundation, Resource, BodiIntegration, UserRow } from "../types";
+import type { Program, Progression, Foundation, Resource, BodiIntegration, UserRow, WeekTemplate } from "../types";
 import { escapeHtml, escapeAttr } from "../utils/html";
 import { findActiveProgression } from "../domain/schedule";
 
@@ -219,5 +219,104 @@ export function bodiSection(items: BodiIntegration[]): string {
   return `<div class="section-header">BODi Integration</div>
 <div class="card">
 ${itemsHtml}
+</div>`;
+}
+
+// ── Import Program section ──────────────────────────────────────────
+
+/**
+ * Collapsible "Import New Program" section shown at the bottom of the
+ * Program page. Mirrors the setup page upload/validate flow but posts
+ * to /api/validate-import-program and /api/import-program.
+ *
+ * Signals used (all scoped to this element via data-signals):
+ *   $import_open        — whether the section is expanded
+ *   $import_program_json — the uploaded JSON string
+ *   $import_template_id  — the selected week template ID
+ */
+export function importProgramSection(): string {
+  return `<div data-signals:import-open="false" data-signals:import-program-json="''" data-signals:import-template-id="''">
+  <div class="section-header" style="display:flex;align-items:center;justify-content:space-between">
+    <span>Import Program</span>
+    <button
+      class="btn btn-blue"
+      style="font-size:12px;padding:4px 12px;height:auto"
+      data-on:click="$importOpen = !$importOpen"
+    >
+      <span data-text="$importOpen ? 'Cancel' : 'Upload JSON'">Upload JSON</span>
+    </button>
+  </div>
+
+  <div data-show="$importOpen">
+    <div class="card" style="margin-bottom:12px">
+      <div class="form-group" style="margin-bottom:16px">
+        <label class="form-label">Program JSON File</label>
+        <input type="file" accept=".json" class="form-input"
+          data-on:change="
+            const f = evt.target.files[0];
+            if (!f) return;
+            f.text().then(t => {
+              const el = document.getElementById('importProgramData');
+              el.value = t;
+              el.dispatchEvent(new Event('input', {bubbles: true}));
+              $importTemplateId = '';
+              document.getElementById('import-validation-result').innerHTML = '';
+            });
+          " />
+        <input type="text" id="importProgramData" data-bind:import-program-json style="display:none" />
+      </div>
+      <button
+        class="btn btn-blue btn-block"
+        data-on:click="@post('/api/validate-import-program')"
+      >
+        Validate &amp; Preview
+      </button>
+    </div>
+
+    <div id="import-validation-result"></div>
+
+    <div data-show="$importTemplateId !== ''" style="margin-top:12px">
+      <button
+        class="btn btn-blue btn-block"
+        data-on:click="@post('/api/import-program')"
+      >
+        Apply Program
+      </button>
+    </div>
+  </div>
+</div>`;
+}
+
+/**
+ * SSE fragment: week template selection cards for the import flow.
+ * Rendered inside #import-validation-result after successful validation.
+ * Clicking a card sets $importTemplateId and shows the Apply button.
+ */
+export function importTemplateSelectionFragment(templates: WeekTemplate[]): string {
+  const sorted = [...templates].sort(
+    (a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0)
+  );
+
+  const templateCards = sorted
+    .map(
+      (t) =>
+        `<div
+  class="template-card"
+  data-on:click="$importTemplateId = '${escapeAttr(t.id)}'"
+  data-class:selected="$importTemplateId === '${escapeAttr(t.id)}'"
+>
+  <div class="template-name">${escapeHtml(t.name)}</div>
+  ${t.description ? `<div class="template-desc">${escapeHtml(t.description)}</div>` : ""}
+</div>`
+    )
+    .join("\n    ");
+
+  return `<div class="card" style="margin-bottom:0">
+  <div class="form-group" style="margin-bottom:0">
+    <label class="form-label">Choose Schedule</label>
+    <div class="template-grid">
+    ${templateCards}
+    </div>
+  </div>
 </div>`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ import {
   clearWebhookState,
   updateLastSyncAt,
   getUserByWebhookToken,
+  clearPendingQueueItems,
+  clearMappings,
 } from "./storage/queries";
 import { generatePlaylist, getNextRoutine, getCompletedRoutines } from "./domain/queue";
 import { computeUpcoming } from "./domain/reflow";
@@ -43,7 +45,7 @@ import { carsCard, heroRoutineCard, completedSection, upcomingSection, syncButto
 import { routineDetailPage } from "./fragments/routine-detail";
 import { skillCards, roadmapSection, benchmarksSection } from "./fragments/progress";
 import { setupPage, templateSelectionFragment } from "./fragments/setup";
-import { programOverview, progressionsSection, routinesSection, foundationsSection, resourcesSection, bodiSection } from "./fragments/program";
+import { programOverview, progressionsSection, routinesSection, foundationsSection, resourcesSection, bodiSection, importProgramSection, importTemplateSelectionFragment } from "./fragments/program";
 import type { Program } from "./types";
 import { escapeHtml } from "./utils/html";
 
@@ -221,6 +223,16 @@ export default {
       // ── POST /api/validate-program ─────────────────────────────
       if (method === "POST" && path === "/api/validate-program") {
         return await handleValidateProgram(request);
+      }
+
+      // ── POST /api/validate-import-program ──────────────────────
+      if (method === "POST" && path === "/api/validate-import-program") {
+        return await handleValidateImportProgram(request);
+      }
+
+      // ── POST /api/import-program ────────────────────────────────
+      if (method === "POST" && path === "/api/import-program") {
+        return await handleImportProgram(request, env, auth.userId, tz);
       }
 
       // ── POST /api/setup/:templateId ─────────────────────────────
@@ -471,6 +483,9 @@ async function handleProgramSSE(env: Env, userId: string): Promise<Response> {
     addFragment(bodiSection(program.bodi));
   }
 
+  // Import section — always shown at the bottom of the Program page
+  addFragment(importProgramSection());
+
   return sseResponse(mergeFragments(fragments));
 }
 
@@ -558,10 +573,36 @@ async function handleSetup(request: Request, env: Env, userId: string, urlTempla
     hevy_api_key: apiKey,
   });
 
-  // a. Store program in D1
-  await insertProgram(env.DB, userId, programJsonStr);
+  // a-j. Store program, sync Hevy templates/routines, generate queue
+  await activateProgram(env.DB, userId, program, programJsonStr, templateId, apiKey);
 
-  // b-g. Hevy exercise template & routine creation (only with API key)
+  // k. Redirect to Today
+  return sseResponse(executeScript("window.location.href = '/'"));
+}
+
+/**
+ * Activate a program: clear old pending queue and mappings, store in D1,
+ * sync to Hevy (exercise templates + routines), then generate queue.
+ * Reused by both initial setup (handleSetup) and program import (handleImportProgram).
+ */
+async function activateProgram(
+  db: D1Database,
+  userId: string,
+  program: Program,
+  programJsonStr: string,
+  templateId: string,
+  apiKey: string | undefined
+): Promise<void> {
+  const template = program.weekTemplates.find((t) => t.id === templateId)!;
+
+  // 1. Clear existing pending queue items and mappings (preserve completed history)
+  await clearPendingQueueItems(db, userId);
+  await clearMappings(db, userId);
+
+  // 2. Insert program (deactivates previous via batch in insertProgram)
+  await insertProgram(db, userId, programJsonStr);
+
+  // 3. Hevy exercise template & routine creation (only with API key)
   const routineIdMap = new Map<string, string>();
   if (apiKey) {
     const client = new HevyClient(apiKey);
@@ -591,7 +632,7 @@ async function handleSetup(request: Request, env: Env, userId: string, urlTempla
 
     // e. Save all exercise template mappings
     for (const [programTemplateId, hevyTemplateId] of matched) {
-      await upsertExerciseTemplateMapping(env.DB, {
+      await upsertExerciseTemplateMapping(db, {
         user_id: userId,
         program_template_id: programTemplateId,
         hevy_template_id: hevyTemplateId,
@@ -600,8 +641,8 @@ async function handleSetup(request: Request, env: Env, userId: string, urlTempla
     }
 
     // f. Create or update Hevy routines with folder grouping + dedup
-    const allMappings = await getExerciseTemplateMappings(env.DB, userId);
-    const existingRoutineMappings = await getRoutineMappings(env.DB, userId);
+    const allMappings = await getExerciseTemplateMappings(db, userId);
+    const existingRoutineMappings = await getRoutineMappings(db, userId);
     const existingMappingsMap = new Map(
       existingRoutineMappings.map((m) => [m.program_routine_id, m.hevy_routine_id])
     );
@@ -646,7 +687,7 @@ async function handleSetup(request: Request, env: Env, userId: string, urlTempla
 
     // g. Save all routine mappings
     for (const [programRoutineId, hevyRoutineId] of routineIdMap) {
-      await upsertRoutineMapping(env.DB, {
+      await upsertRoutineMapping(db, {
         user_id: userId,
         program_routine_id: programRoutineId,
         hevy_routine_id: hevyRoutineId,
@@ -654,20 +695,126 @@ async function handleSetup(request: Request, env: Env, userId: string, urlTempla
     }
   }
 
-  // i. Generate queue playlist
+  // 4. Generate queue playlist and insert items
   const weeks = program.meta.durationWeeks || 8;
   const playlist = generatePlaylist(template, program.routines, weeks);
   if (playlist.length > 0) {
-    await insertQueueItems(env.DB, userId, playlist);
+    await insertQueueItems(db, userId, playlist);
   }
 
-  // j. Bulk-set hevy_routine_id on queue items via routine_mappings
+  // 5. Bulk-set hevy_routine_id on queue items via routine_mappings
   if (apiKey) {
-    await bulkSetQueueItemRoutineIds(env.DB, userId, routineIdMap);
+    await bulkSetQueueItemRoutineIds(db, userId, routineIdMap);
+  }
+}
+
+/** POST /api/validate-import-program — validate uploaded JSON for the import flow */
+async function handleValidateImportProgram(request: Request): Promise<Response> {
+  const body = (await request.json()) as Record<string, unknown>;
+  const programJsonStr = body.programJson as string | undefined;
+
+  if (!programJsonStr) {
+    return sseResponse(
+      patchElements(
+        `<div class="card"><p style="color:var(--orange)">No program JSON provided.</p></div>`,
+        { selector: "#import-validation-result", mode: "inner" }
+      )
+    );
   }
 
-  // k. Redirect to Today
-  return sseResponse(executeScript("window.location.href = '/'"));
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(programJsonStr);
+  } catch {
+    return sseResponse(
+      patchElements(
+        `<div class="card"><p style="color:var(--orange)">Invalid JSON file.</p></div>`,
+        { selector: "#import-validation-result", mode: "inner" }
+      )
+    );
+  }
+
+  const result = validateProgram(parsed);
+  if (!result.valid) {
+    const errorList = result.errors
+      .map((e) => `<li>${escapeHtml(e)}</li>`)
+      .join("");
+    return sseResponse(
+      patchElements(
+        `<div class="card"><p style="color:var(--orange)">Validation errors:</p><ul style="margin:8px 0 0 16px;font-size:13px;color:var(--text-secondary)">${errorList}</ul></div>`,
+        { selector: "#import-validation-result", mode: "inner" }
+      )
+    );
+  }
+
+  return sseResponse(
+    patchElements(importTemplateSelectionFragment(result.program.weekTemplates), {
+      selector: "#import-validation-result",
+      mode: "inner",
+    })
+  );
+}
+
+/** POST /api/import-program — replace active program, re-sync Hevy, regenerate queue */
+async function handleImportProgram(request: Request, env: Env, userId: string, tz?: string): Promise<Response> {
+  let body: { programJson?: string; templateId?: string } = {};
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return new Response("Invalid request body", { status: 400 });
+  }
+
+  const { programJson: programJsonStr, templateId } = body;
+
+  if (!programJsonStr) {
+    return sseResponse(
+      patchElements(
+        `<div class="card"><p style="color:var(--orange)">No program JSON provided.</p></div>`,
+        { selector: "#import-validation-result", mode: "inner" }
+      )
+    );
+  }
+
+  if (!templateId) {
+    return new Response("Template ID is required", { status: 400 });
+  }
+
+  // Parse and validate program
+  let program: Program;
+  try {
+    const parsed = JSON.parse(programJsonStr);
+    const result = validateProgram(parsed);
+    if (!result.valid) {
+      return new Response(`Invalid program: ${result.errors.join(", ")}`, { status: 400 });
+    }
+    program = result.program;
+  } catch {
+    return new Response("Invalid program JSON", { status: 400 });
+  }
+
+  if (!program.weekTemplates.find((t) => t.id === templateId)) {
+    return new Response("Invalid template ID", { status: 400 });
+  }
+
+  // Get the user's existing API key and start_date
+  const user = await getUser(env.DB, userId);
+  const apiKey = user?.hevy_api_key ?? undefined;
+  const startDate = todayString(tz);
+
+  // Update user record with new program info (preserves API key via COALESCE)
+  await upsertUser(env.DB, {
+    id: userId,
+    active_program: program.meta.title,
+    template_id: templateId,
+    start_date: startDate,
+    hevy_api_key: undefined,
+  });
+
+  // Activate: clear old state, sync to Hevy, generate queue
+  await activateProgram(env.DB, userId, program, programJsonStr, templateId, apiKey);
+
+  // Re-render the Program page
+  return await handleProgramSSE(env, userId);
 }
 
 /** POST /api/push-hevy/:id — open routine in Hevy (uses existing mapping from setup) */

--- a/src/storage/queries.ts
+++ b/src/storage/queries.ts
@@ -235,3 +235,14 @@ export async function getUserByWebhookToken(
     .bind(authToken)
     .first<UserRow>();
 }
+
+/** Delete only pending queue items for a user (preserve completed for history) */
+export async function clearPendingQueueItems(db: D1Database, userId: string): Promise<void> {
+  await db.prepare("DELETE FROM queue_items WHERE user_id = ? AND status = 'pending'").bind(userId).run();
+}
+
+/** Clear all exercise template and routine mappings for a user */
+export async function clearMappings(db: D1Database, userId: string): Promise<void> {
+  await db.prepare("DELETE FROM exercise_template_mappings WHERE user_id = ?").bind(userId).run();
+  await db.prepare("DELETE FROM routine_mappings WHERE user_id = ?").bind(userId).run();
+}


### PR DESCRIPTION
## Summary
- Extract `activateProgram` from `handleSetup` for reuse (clear pending queue + mappings, store program, sync Hevy, generate queue)
- Add "Import Program" collapsible section to Program page with file upload, JSON validation, template selection
- Two new routes: `POST /api/validate-import-program` and `POST /api/import-program`
- Preserves completed queue items for history; only clears pending items and mappings on import

## Test plan
- [x] All 56 tests pass
- [ ] Upload a valid program JSON → verify validation shows template cards
- [ ] Select template and apply → verify program replaces active, queue regenerated
- [ ] Upload invalid JSON → verify error messages
- [ ] Verify existing setup flow still works (refactored to use `activateProgram`)
- [ ] Verify completed queue items preserved after import

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)