### PR TITLE
Encrypt Hevy API key at rest with AES-256-GCM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ import { programOverview, progressionsSection, routinesSection, foundationsSecti
 import type { Program } from "./types";
 import { escapeHtml } from "./utils/html";
 import { todayString, toLocalDate } from "./utils/date";
+import { getDecryptedApiKey } from "./storage/api-key";
+import { encryptAesGcm } from "./utils/crypto";
 
 import defaultProgramJson from "../programs/mobility-joint-restoration.json";
 
@@ -58,6 +60,8 @@ export interface Env {
   DB: D1Database;
   ENVIRONMENT: string;
   CF_ACCESS_AUD?: string;
+  /** AES-256 key in hex (64 chars). Set via `wrangler secret put ENCRYPTION_KEY`. */
+  ENCRYPTION_KEY: string;
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -588,12 +592,14 @@ async function handleSetup(request: Request, env: Env, userId: string, urlTempla
   }
 
   // h. Upsert user (must exist before program insert due to FK constraint)
+  // Encrypt the API key before storage; pass undefined when no key provided.
+  const encryptedApiKey = apiKey ? await encryptAesGcm(apiKey, env.ENCRYPTION_KEY) : undefined;
   await upsertUser(env.DB, {
     id: userId,
     active_program: program.meta.title,
     template_id: templateId,
     start_date: startDate,
-    hevy_api_key: apiKey,
+    hevy_api_key: encryptedApiKey,
     timezone: tz,
   });
 
@@ -801,8 +807,9 @@ async function handleImportProgram(request: Request, env: Env, userId: string, t
     return sseErrorCard("Invalid template ID.", "#import-validation-result", "inner");
   }
 
-  // Update user program fields and get existing API key in one pass
-  const apiKey = await updateUserProgram(env.DB, userId, program.meta.title, templateId, todayString(tz)) ?? undefined;
+  // Update user program fields and get existing (encrypted) API key in one pass, then decrypt
+  const storedKey = await updateUserProgram(env.DB, userId, program.meta.title, templateId, todayString(tz));
+  const apiKey = storedKey ? (await getDecryptedApiKey(env.DB, userId, env.ENCRYPTION_KEY)) ?? undefined : undefined;
 
   // Activate: clear old state, sync to Hevy, generate queue
   await activateProgram(env.DB, userId, program, programJsonStr, templateId, apiKey);
@@ -836,7 +843,11 @@ async function handlePush(env: Env, userId: string, routineId: string): Promise<
     return new Response("Routine not found", { status: 404 });
   }
 
-  const client = new HevyClient(user.hevy_api_key);
+  const apiKey = await getDecryptedApiKey(env.DB, userId, env.ENCRYPTION_KEY);
+  if (!apiKey) {
+    return sseErrorCard("Connect your Hevy API key first.", "#content", "inner");
+  }
+  const client = new HevyClient(apiKey);
 
   // Get or auto-create exercise template mappings
   let mappings = await getExerciseTemplateMappings(env.DB, userId);
@@ -906,7 +917,11 @@ async function handleCleanupRoutines(env: Env, userId: string): Promise<Response
     return sseErrorCard("Connect your Hevy API key first.");
   }
 
-  const client = new HevyClient(user.hevy_api_key);
+  const apiKey = await getDecryptedApiKey(env.DB, userId, env.ENCRYPTION_KEY);
+  if (!apiKey) {
+    return sseErrorCard("Connect your Hevy API key first.");
+  }
+  const client = new HevyClient(apiKey);
   const allRoutines = await client.getAllRoutines();
 
   // Group by title+folder, find duplicates
@@ -1030,7 +1045,11 @@ async function handlePull(env: Env, userId: string, tz?: string): Promise<Respon
   }
 
   try {
-    await performSync(env.DB, userId, user.hevy_api_key, tz);
+    const apiKey = await getDecryptedApiKey(env.DB, userId, env.ENCRYPTION_KEY);
+    if (!apiKey) {
+      return sseErrorCard("Connect your Hevy API key first.", "#content", "inner");
+    }
+    await performSync(env.DB, userId, apiKey, tz);
     return await handleTodaySSE(env, userId, tz);
   } catch (err) {
     return sseErrorCard(err instanceof Error ? err.message : "Pull failed");
@@ -1052,7 +1071,11 @@ async function handleWebhookRegister(
   try {
     const authToken = crypto.randomUUID();
     const webhookUrl = `${new URL(request.url).origin}/api/webhooks/hevy`;
-    const client = new HevyClient(user.hevy_api_key);
+    const apiKey = await getDecryptedApiKey(env.DB, userId, env.ENCRYPTION_KEY);
+    if (!apiKey) {
+      return sseErrorCard("Connect your Hevy API key first.");
+    }
+    const client = new HevyClient(apiKey);
     const sub = await client.createWebhookSubscription(webhookUrl, authToken);
     await updateWebhookState(env.DB, userId, sub.id, authToken);
     return await handleTodaySSE(env, userId, tz);
@@ -1074,8 +1097,11 @@ async function handleWebhookUnregister(
 
   try {
     if (user.hevy_api_key && user.webhook_id) {
-      const client = new HevyClient(user.hevy_api_key);
-      await client.deleteWebhookSubscription(user.webhook_id);
+      const apiKey = await getDecryptedApiKey(env.DB, userId, env.ENCRYPTION_KEY);
+      if (apiKey) {
+        const client = new HevyClient(apiKey);
+        await client.deleteWebhookSubscription(user.webhook_id);
+      }
     }
     await clearWebhookState(env.DB, userId);
     return await handleTodaySSE(env, userId, tz);
@@ -1123,8 +1149,11 @@ async function handleWebhookEvent(
   // Run sync in the background via waitUntil so the response is not delayed
   if (user.hevy_api_key) {
     ctx.waitUntil(
-      performSync(env.DB, user.id, user.hevy_api_key, user.timezone ?? undefined).catch((err) => {
-        console.error("Webhook sync failed:", err instanceof Error ? err.message : err);
+      getDecryptedApiKey(env.DB, user.id, env.ENCRYPTION_KEY).then((apiKey) => {
+        if (!apiKey) return;
+        return performSync(env.DB, user.id, apiKey, user.timezone ?? undefined).catch((err) => {
+          console.error("Webhook sync failed:", err instanceof Error ? err.message : err);
+        });
       })
     );
   }

--- a/src/storage/api-key.ts
+++ b/src/storage/api-key.ts
@@ -1,0 +1,38 @@
+import { encryptAesGcm, decryptAesGcm } from "../utils/crypto";
+
+/**
+ * Store an encrypted Hevy API key for a user.
+ * Encrypts using AES-256-GCM before writing to D1.
+ */
+export async function setEncryptedApiKey(
+  db: D1Database,
+  userId: string,
+  apiKey: string,
+  encryptionKey: string
+): Promise<void> {
+  const encrypted = await encryptAesGcm(apiKey, encryptionKey);
+  await db.prepare("UPDATE users SET hevy_api_key = ? WHERE id = ?").bind(encrypted, userId).run();
+}
+
+/**
+ * Read and decrypt the Hevy API key for a user.
+ * Returns null if no key is stored.
+ * Handles both legacy plaintext values and AES-GCM encrypted values transparently:
+ * encrypted values contain a colon separator ("base64:base64"); Hevy API keys never do.
+ */
+export async function getDecryptedApiKey(
+  db: D1Database,
+  userId: string,
+  encryptionKey: string
+): Promise<string | null> {
+  const row = await db
+    .prepare("SELECT hevy_api_key FROM users WHERE id = ?")
+    .bind(userId)
+    .first<{ hevy_api_key: string | null }>();
+  if (!row?.hevy_api_key) return null;
+  // Legacy plaintext — Hevy API keys never contain a colon
+  if (!row.hevy_api_key.includes(":")) {
+    return row.hevy_api_key;
+  }
+  return decryptAesGcm(row.hevy_api_key, encryptionKey);
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -7,3 +7,54 @@ export async function sha256Hex(input: string): Promise<string> {
   const hash = await crypto.subtle.digest("SHA-256", encoded);
   return [...new Uint8Array(hash)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
+
+/**
+ * Encrypt a string using AES-256-GCM.
+ * Returns a "base64(iv):base64(ciphertext)" string.
+ * The key must be a 64-character hex string (32 bytes).
+ */
+export async function encryptAesGcm(plaintext: string, keyHex: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    hexToBytes(keyHex),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"]
+  );
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plaintext);
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, encoded);
+  return (
+    btoa(String.fromCharCode(...iv)) +
+    ":" +
+    btoa(String.fromCharCode(...new Uint8Array(ciphertext)))
+  );
+}
+
+/**
+ * Decrypt an AES-256-GCM encrypted string.
+ * Expects a "base64(iv):base64(ciphertext)" string produced by encryptAesGcm.
+ * The key must be a 64-character hex string (32 bytes).
+ */
+export async function decryptAesGcm(encrypted: string, keyHex: string): Promise<string> {
+  const [ivB64, ctB64] = encrypted.split(":");
+  const iv = Uint8Array.from(atob(ivB64), (c) => c.charCodeAt(0));
+  const ciphertext = Uint8Array.from(atob(ctB64), (c) => c.charCodeAt(0));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    hexToBytes(keyHex),
+    { name: "AES-GCM" },
+    false,
+    ["decrypt"]
+  );
+  const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
+  return new TextDecoder().decode(decrypted);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substr(i, 2), 16);
+  }
+  return bytes;
+}


### PR DESCRIPTION
## Summary
- Add AES-256-GCM encrypt/decrypt utilities to `src/utils/crypto.ts`
- New `src/storage/api-key.ts` with `getDecryptedApiKey` and `setEncryptedApiKey`
- All API key read paths decrypt via `getDecryptedApiKey(db, userId, env.ENCRYPTION_KEY)`
- Setup encrypts before storing via `encryptAesGcm`
- Legacy plaintext values handled transparently (no colon = plaintext)
- Encryption key set via `wrangler secret put ENCRYPTION_KEY`

## Test plan
- [x] All 56 tests pass
- [ ] Set ENCRYPTION_KEY secret, run setup → verify key stored encrypted in D1
- [ ] Verify all sync/push operations still work with encrypted key
- [ ] Verify legacy plaintext keys still decrypt correctly

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)