### PR TITLE
Multiple program support with library and switching

### DIFF
--- a/migrations/0009_multi_program.sql
+++ b/migrations/0009_multi_program.sql
@@ -1,0 +1,21 @@
+-- Add program_id to scope queue and mappings per program
+ALTER TABLE queue_items ADD COLUMN program_id INTEGER REFERENCES programs(id);
+ALTER TABLE exercise_template_mappings ADD COLUMN program_id INTEGER REFERENCES programs(id);
+ALTER TABLE routine_mappings ADD COLUMN program_id INTEGER REFERENCES programs(id);
+
+-- Backfill existing data with the active program
+UPDATE queue_items SET program_id = (
+  SELECT p.id FROM programs p
+  WHERE p.user_id = queue_items.user_id AND p.is_active = 1
+  ORDER BY p.created_at DESC LIMIT 1
+);
+UPDATE exercise_template_mappings SET program_id = (
+  SELECT p.id FROM programs p
+  WHERE p.user_id = exercise_template_mappings.user_id AND p.is_active = 1
+  ORDER BY p.created_at DESC LIMIT 1
+);
+UPDATE routine_mappings SET program_id = (
+  SELECT p.id FROM programs p
+  WHERE p.user_id = routine_mappings.user_id AND p.is_active = 1
+  ORDER BY p.created_at DESC LIMIT 1
+);

--- a/src/fragments/program.ts
+++ b/src/fragments/program.ts
@@ -3,7 +3,7 @@
 // foundations, resources, BODi, import
 // ──────────────────────────────────────────────────────────────────
 
-import type { Program, Progression, Foundation, Resource, BodiIntegration, UserRow, WeekTemplate } from "../types";
+import type { Program, Progression, Foundation, Resource, BodiIntegration, UserRow, WeekTemplate, ProgramRow } from "../types";
 import { escapeHtml, escapeAttr } from "../utils/html";
 import { findActiveProgression } from "../domain/schedule";
 import { renderTemplateGrid } from "./template-grid";
@@ -220,6 +220,56 @@ export function bodiSection(items: BodiIntegration[]): string {
   return `<div class="section-header">BODi Integration</div>
 <div class="card">
 ${itemsHtml}
+</div>`;
+}
+
+// ── Program Library section ──────────────────────────────────────────
+
+/**
+ * Lists all programs in the user's library with switch/delete actions.
+ * Only shown when more than one program exists.
+ */
+export function programLibrarySection(programs: ProgramRow[]): string {
+  const items = programs.map((p) => {
+    const parsed = (() => {
+      try {
+        return JSON.parse(p.json_data) as { meta?: { title?: string; subtitle?: string } };
+      } catch {
+        return null;
+      }
+    })();
+    const title = parsed?.meta?.title ?? `Program #${p.id}`;
+    const subtitle = parsed?.meta?.subtitle;
+    const isActive = p.is_active === 1;
+    const uploadedDate = p.created_at.slice(0, 10);
+
+    const activeBadge = isActive
+      ? `<span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;color:var(--green);background:rgba(48,209,88,0.12);padding:2px 8px;border-radius:4px;margin-left:8px">Active</span>`
+      : "";
+
+    const actions = isActive
+      ? ""
+      : `<div style="display:flex;gap:8px;margin-top:8px">
+  <button class="btn btn-blue" style="font-size:12px;padding:4px 14px;height:auto"
+    data-on:click="@post('/api/switch-program/${p.id}')">Switch To</button>
+  <button class="btn" style="font-size:12px;padding:4px 14px;height:auto;color:var(--orange);border-color:var(--orange)"
+    data-on:click="@post('/api/delete-program/${p.id}')">Delete</button>
+</div>`;
+
+    return `<div style="padding:12px 0;${isActive ? "" : "opacity:0.75"}">
+  <div style="display:flex;align-items:center">
+    <span style="font-size:15px;font-weight:600">${escapeHtml(title)}</span>
+    ${activeBadge}
+  </div>
+  ${subtitle ? `<div style="font-size:13px;color:var(--text-secondary);margin-top:2px">${escapeHtml(subtitle)}</div>` : ""}
+  <div style="font-size:12px;color:var(--text-tertiary);margin-top:2px">Imported ${escapeHtml(uploadedDate)}</div>
+  ${actions}
+</div>`;
+  }).join(`<div style="border-top:1px solid var(--separator)"></div>`);
+
+  return `<div class="section-header">Program Library</div>
+<div class="card">
+${items}
 </div>`;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ import {
   bulkSetQueueItemRoutineIds,
   insertProgram,
   getActiveProgram,
+  getPrograms,
+  setActiveProgram,
+  deleteProgram,
   updateDailyCompleted,
   updateWebhookState,
   clearWebhookState,
@@ -45,7 +48,7 @@ import { carsCard, heroRoutineCard, completedSection, upcomingSection, syncButto
 import { routineDetailPage } from "./fragments/routine-detail";
 import { skillCards, roadmapSection, benchmarksSection } from "./fragments/progress";
 import { setupPage, templateSelectionFragment } from "./fragments/setup";
-import { programOverview, progressionsSection, routinesSection, foundationsSection, resourcesSection, bodiSection, importProgramSection, importTemplateSelectionFragment } from "./fragments/program";
+import { programOverview, progressionsSection, routinesSection, foundationsSection, resourcesSection, bodiSection, importProgramSection, importTemplateSelectionFragment, programLibrarySection } from "./fragments/program";
 import type { Program } from "./types";
 import { escapeHtml } from "./utils/html";
 import { todayString, toLocalDate } from "./utils/date";
@@ -84,18 +87,18 @@ function sseErrorCard(
 /** Load the subtitle from the active program, or undefined on failure. */
 async function loadSubtitle(db: D1Database, userId: string): Promise<string | undefined> {
   try {
-    const prog = await loadProgram(db, userId);
-    return prog.meta.subtitle;
+    const { program } = await loadProgram(db, userId);
+    return program.meta.subtitle;
   } catch {
     return undefined;
   }
 }
 
-/** Load the active program from D1 for a given user. */
-async function loadProgram(db: D1Database, userId: string): Promise<Program> {
+/** Load the active program from D1 for a given user. Returns the program and its D1 row ID. */
+async function loadProgram(db: D1Database, userId: string): Promise<{ program: Program; programId: number }> {
   const row = await getActiveProgram(db, userId);
   if (!row) throw new Error("No active program found");
-  return JSON.parse(row.json_data) as Program;
+  return { program: JSON.parse(row.json_data) as Program, programId: row.id };
 }
 
 function htmlResponse(body: string): Response {
@@ -285,6 +288,18 @@ export default {
         return await handleWebhookUnregister(env, auth.userId, tz);
       }
 
+      // ── POST /api/switch-program/:id ───────────────────────────
+      let switchMatch: RegExpMatchArray | null;
+      if (method === "POST" && (switchMatch = path.match(/^\/api\/switch-program\/(\d+)$/))) {
+        return await handleSwitchProgram(env, auth.userId, parseInt(switchMatch[1], 10), tz);
+      }
+
+      // ── POST /api/delete-program/:id ───────────────────────────
+      let deleteMatch: RegExpMatchArray | null;
+      if (method === "POST" && (deleteMatch = path.match(/^\/api\/delete-program\/(\d+)$/))) {
+        return await handleDeleteProgram(env, auth.userId, parseInt(deleteMatch[1], 10));
+      }
+
       // ── 404 ────────────────────────────────────────────────────
       return new Response("Not Found", { status: 404 });
     } catch (err) {
@@ -365,15 +380,15 @@ async function handleTodaySSE(env: Env, userId: string, tz?: string): Promise<Re
     );
   }
 
-  const program = await loadProgram(env.DB, userId);
+  const { program, programId } = await loadProgram(env.DB, userId);
   const routineMap = new Map(program.routines.map((r) => [r.id, r]));
   const dailyRoutine = program.routines.find((r) => r.isDaily);
 
-  const items = await getQueueItems(env.DB, userId);
+  const items = await getQueueItems(env.DB, userId, programId);
   const today = todayString(tz);
 
   // Look up routine mappings for deep links
-  const routineMappings = await getRoutineMappings(env.DB, userId);
+  const routineMappings = await getRoutineMappings(env.DB, userId, programId);
   const routineToHevyId = new Map(
     routineMappings.map((m) => [m.program_routine_id, m.hevy_routine_id])
   );
@@ -437,7 +452,7 @@ async function handleTodaySSE(env: Env, userId: string, tz?: string): Promise<Re
 
 /** SSE: Progress page — skills, roadmap, benchmarks */
 async function handleProgressSSE(env: Env, userId: string): Promise<Response> {
-  const program = await loadProgram(env.DB, userId);
+  const { program } = await loadProgram(env.DB, userId);
   const fragments: string[] = [];
   let isFirst = true;
 
@@ -465,11 +480,16 @@ async function handleProgressSSE(env: Env, userId: string): Promise<Response> {
 async function handleProgramSSE(env: Env, userId: string): Promise<Response> {
   let program: Program;
   let user: Awaited<ReturnType<typeof getUser>>;
+  let allPrograms: Awaited<ReturnType<typeof getPrograms>>;
   try {
-    [program, user] = await Promise.all([
+    const [loaded, userRow, programRows] = await Promise.all([
       loadProgram(env.DB, userId),
       getUser(env.DB, userId),
+      getPrograms(env.DB, userId),
     ]);
+    program = loaded.program;
+    user = userRow;
+    allPrograms = programRows;
   } catch {
     return sseResponse(
       patchElements(`<div class="card"><p style="color:var(--text-secondary)">No active program. Upload a program to get started.</p></div>`, {
@@ -486,6 +506,11 @@ async function handleProgramSSE(env: Env, userId: string): Promise<Response> {
   };
 
   const week = user ? currentWeek(user.start_date) : null;
+
+  // Program Library section — always shown first (only when > 1 program exists)
+  if (allPrograms.length > 1) {
+    addFragment(programLibrarySection(allPrograms));
+  }
 
   addFragment(programOverview(program, user, week));
 
@@ -515,7 +540,7 @@ async function handleProgramSSE(env: Env, userId: string): Promise<Response> {
 
 /** SSE: Routine detail — exercise list with coaching context */
 async function handleRoutineSSE(env: Env, userId: string, routineId: string): Promise<Response> {
-  const program = await loadProgram(env.DB, userId);
+  const { program } = await loadProgram(env.DB, userId);
   const routine = program.routines.find((r) => r.id === routineId);
   if (!routine) {
     return sseResponse(
@@ -621,10 +646,11 @@ async function activateProgram(
   if (!template) throw new Error(`Week template "${templateId}" not found in program`);
 
   // 1. Clear existing pending queue items and mappings atomically (preserve completed history)
+  // Clear globally (no programId) since we're replacing the active program
   await clearPendingStateForUser(db, userId);
 
-  // 2. Insert program (deactivates previous via batch in insertProgram)
-  await insertProgram(db, userId, programJsonStr);
+  // 2. Insert program (deactivates previous via batch in insertProgram) — get the new row ID
+  const programId = await insertProgram(db, userId, programJsonStr);
 
   // 3. Hevy exercise template & routine creation (only with API key)
   const routineIdMap = new Map<string, string>();
@@ -654,14 +680,15 @@ async function activateProgram(
       }
     }
 
-    // e. Save all exercise template mappings (batched)
+    // e. Save all exercise template mappings (batched), scoped to new programId
     if (matched.size > 0) {
       const upsertTemplateStmt = db.prepare(
-        `INSERT INTO exercise_template_mappings (user_id, program_template_id, hevy_template_id, is_custom)
-         VALUES (?, ?, ?, ?)
+        `INSERT INTO exercise_template_mappings (user_id, program_template_id, hevy_template_id, is_custom, program_id)
+         VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(user_id, program_template_id) DO UPDATE SET
            hevy_template_id = excluded.hevy_template_id,
-           is_custom = excluded.is_custom`
+           is_custom = excluded.is_custom,
+           program_id = excluded.program_id`
       );
       await db.batch(
         [...matched.entries()].map(([programTemplateId, hevyTemplateId]) =>
@@ -669,15 +696,16 @@ async function activateProgram(
             userId,
             programTemplateId,
             hevyTemplateId,
-            customCreated.has(programTemplateId) ? 1 : 0
+            customCreated.has(programTemplateId) ? 1 : 0,
+            programId
           )
         )
       );
     }
 
     // f. Create or update Hevy routines with folder grouping + dedup
-    const allMappings = await getExerciseTemplateMappings(db, userId);
-    const existingRoutineMappings = await getRoutineMappings(db, userId);
+    const allMappings = await getExerciseTemplateMappings(db, userId, programId);
+    const existingRoutineMappings = await getRoutineMappings(db, userId, programId);
     const existingMappingsMap = new Map(
       existingRoutineMappings.map((m) => [m.program_routine_id, m.hevy_routine_id])
     );
@@ -727,27 +755,28 @@ async function activateProgram(
       }
     }
 
-    // g. Save all routine mappings (batched)
+    // g. Save all routine mappings (batched), scoped to new programId
     if (routineIdMap.size > 0) {
       const upsertRoutineStmt = db.prepare(
-        `INSERT INTO routine_mappings (user_id, program_routine_id, hevy_routine_id)
-         VALUES (?, ?, ?)
+        `INSERT INTO routine_mappings (user_id, program_routine_id, hevy_routine_id, program_id)
+         VALUES (?, ?, ?, ?)
          ON CONFLICT(user_id, program_routine_id) DO UPDATE SET
-           hevy_routine_id = excluded.hevy_routine_id`
+           hevy_routine_id = excluded.hevy_routine_id,
+           program_id = excluded.program_id`
       );
       await db.batch(
         [...routineIdMap.entries()].map(([programRoutineId, hevyRoutineId]) =>
-          upsertRoutineStmt.bind(userId, programRoutineId, hevyRoutineId)
+          upsertRoutineStmt.bind(userId, programRoutineId, hevyRoutineId, programId)
         )
       );
     }
   }
 
-  // 4. Generate queue playlist and insert items
+  // 4. Generate queue playlist and insert items, scoped to new programId
   const weeks = program.meta.durationWeeks || 8;
   const playlist = generatePlaylist(template, program.routines, weeks);
   if (playlist.length > 0) {
-    await insertQueueItems(db, userId, playlist);
+    await insertQueueItems(db, userId, playlist, programId);
   }
 
   // 5. Bulk-set hevy_routine_id on queue items via routine_mappings
@@ -818,8 +847,10 @@ async function handlePush(env: Env, userId: string, routineId: string): Promise<
     return sseErrorCard("Connect your Hevy API key first.", "#content", "inner");
   }
 
-  // Look up existing routine mapping from setup
-  const routineMappings = await getRoutineMappings(env.DB, userId);
+  const { program, programId } = await loadProgram(env.DB, userId);
+
+  // Look up existing routine mapping from setup (scoped to active program)
+  const routineMappings = await getRoutineMappings(env.DB, userId, programId);
   const mapping = routineMappings.find((m) => m.program_routine_id === routineId);
 
   if (mapping) {
@@ -830,7 +861,6 @@ async function handlePush(env: Env, userId: string, routineId: string): Promise<
   }
 
   // Fallback: no mapping exists (edge case — setup didn't create this routine)
-  const program = await loadProgram(env.DB, userId);
   const routine = program.routines.find((r) => r.id === routineId);
   if (!routine) {
     return new Response("Routine not found", { status: 404 });
@@ -838,8 +868,8 @@ async function handlePush(env: Env, userId: string, routineId: string): Promise<
 
   const client = new HevyClient(user.hevy_api_key);
 
-  // Get or auto-create exercise template mappings
-  let mappings = await getExerciseTemplateMappings(env.DB, userId);
+  // Get or auto-create exercise template mappings (scoped to active program)
+  let mappings = await getExerciseTemplateMappings(env.DB, userId, programId);
   if (mappings.length === 0) {
     try {
       const hevyTemplates = await client.getAllExerciseTemplates();
@@ -851,9 +881,10 @@ async function handlePush(env: Env, userId: string, routineId: string): Promise<
           program_template_id: programTemplateId,
           hevy_template_id: hevyTemplateId,
           is_custom: 0,
+          program_id: programId,
         });
       }
-      mappings = await getExerciseTemplateMappings(env.DB, userId);
+      mappings = await getExerciseTemplateMappings(env.DB, userId, programId);
     } catch {
       // If auto-match fails, continue with empty mappings
     }
@@ -880,10 +911,11 @@ async function handlePush(env: Env, userId: string, routineId: string): Promise<
       user_id: userId,
       program_routine_id: routineId,
       hevy_routine_id: created.id,
+      program_id: programId,
     });
 
-    // Also update the queue item if there is one
-    const items = await getQueueItems(env.DB, userId);
+    // Also update the queue item if there is one (scoped to active program)
+    const items = await getQueueItems(env.DB, userId, programId);
     const queueItem = items.find(
       (i) => i.routine_id === routineId && i.status === "pending"
     );
@@ -956,13 +988,13 @@ async function handleCleanupRoutines(env: Env, userId: string): Promise<Response
  * Updates last_sync_at on successful completion.
  */
 async function performSync(db: D1Database, userId: string, apiKey: string, tz?: string): Promise<void> {
-  const program = await loadProgram(db, userId);
+  const { program, programId } = await loadProgram(db, userId);
   const routineMap = new Map(program.routines.map((r) => [r.id, r]));
   const client = new HevyClient(apiKey);
 
   const [workouts, items] = await Promise.all([
     client.getRecentWorkouts(),
-    getQueueItems(db, userId),
+    getQueueItems(db, userId, programId),
   ]);
 
   // Skip workouts already matched to a completed queue item
@@ -1145,4 +1177,50 @@ async function handleManualComplete(
   const today = todayString(tz);
   await markQueueItemCompletedForUser(env.DB, itemId, userId, today);
   return await handleTodaySSE(env, userId, tz);
+}
+
+/** POST /api/switch-program/:id — switch the active program and re-render the Program page */
+async function handleSwitchProgram(
+  env: Env,
+  userId: string,
+  programId: number,
+  _tz?: string
+): Promise<Response> {
+  try {
+    await setActiveProgram(env.DB, userId, programId);
+    // Update the active_program label on the users row for subtitle display
+    const row = await getActiveProgram(env.DB, userId);
+    if (row) {
+      const prog = JSON.parse(row.json_data) as Program;
+      await env.DB.prepare("UPDATE users SET active_program = ? WHERE id = ?")
+        .bind(prog.meta.title, userId)
+        .run();
+    }
+  } catch (err) {
+    return sseErrorCard(err instanceof Error ? err.message : "Failed to switch program");
+  }
+  return await handleProgramSSE(env, userId);
+}
+
+/** POST /api/delete-program/:id — delete an inactive program */
+async function handleDeleteProgram(
+  env: Env,
+  userId: string,
+  programId: number
+): Promise<Response> {
+  // Verify the program is not active before deleting
+  const programs = await getPrograms(env.DB, userId);
+  const target = programs.find((p) => p.id === programId);
+  if (!target) {
+    return sseErrorCard("Program not found.");
+  }
+  if (target.is_active) {
+    return sseErrorCard("Cannot delete the active program. Switch to another program first.");
+  }
+  try {
+    await deleteProgram(env.DB, userId, programId);
+  } catch (err) {
+    return sseErrorCard(err instanceof Error ? err.message : "Failed to delete program");
+  }
+  return await handleProgramSSE(env, userId);
 }

--- a/src/storage/queries.ts
+++ b/src/storage/queries.ts
@@ -40,23 +40,29 @@ export async function updateUserProgram(
   return row?.hevy_api_key ?? null;
 }
 
-export async function getQueueItems(db: D1Database, userId: string): Promise<QueueItemRow[]> {
-  const result = await db
-    .prepare("SELECT * FROM queue_items WHERE user_id = ? ORDER BY position")
-    .bind(userId)
-    .all<QueueItemRow>();
+export async function getQueueItems(db: D1Database, userId: string, programId?: number): Promise<QueueItemRow[]> {
+  const result = programId != null
+    ? await db
+        .prepare("SELECT * FROM queue_items WHERE user_id = ? AND program_id = ? ORDER BY position")
+        .bind(userId, programId)
+        .all<QueueItemRow>()
+    : await db
+        .prepare("SELECT * FROM queue_items WHERE user_id = ? ORDER BY position")
+        .bind(userId)
+        .all<QueueItemRow>();
   return result.results;
 }
 
 export async function insertQueueItems(
   db: D1Database,
   userId: string,
-  items: Array<{ routine_id: string; position: number }>
+  items: Array<{ routine_id: string; position: number }>,
+  programId?: number
 ): Promise<void> {
   const stmt = db.prepare(
-    "INSERT INTO queue_items (user_id, routine_id, position) VALUES (?, ?, ?)"
+    "INSERT INTO queue_items (user_id, routine_id, position, program_id) VALUES (?, ?, ?, ?)"
   );
-  const batch = items.map((item) => stmt.bind(userId, item.routine_id, item.position));
+  const batch = items.map((item) => stmt.bind(userId, item.routine_id, item.position, programId ?? null));
   await db.batch(batch);
 }
 
@@ -120,12 +126,18 @@ export async function updateQueueItemHevyRoutineId(
 
 export async function getExerciseTemplateMappings(
   db: D1Database,
-  userId: string
+  userId: string,
+  programId?: number
 ): Promise<ExerciseTemplateMappingRow[]> {
-  const result = await db
-    .prepare("SELECT * FROM exercise_template_mappings WHERE user_id = ?")
-    .bind(userId)
-    .all<ExerciseTemplateMappingRow>();
+  const result = programId != null
+    ? await db
+        .prepare("SELECT * FROM exercise_template_mappings WHERE user_id = ? AND program_id = ?")
+        .bind(userId, programId)
+        .all<ExerciseTemplateMappingRow>()
+    : await db
+        .prepare("SELECT * FROM exercise_template_mappings WHERE user_id = ?")
+        .bind(userId)
+        .all<ExerciseTemplateMappingRow>();
   return result.results;
 }
 
@@ -135,24 +147,31 @@ export async function upsertExerciseTemplateMapping(
 ): Promise<void> {
   await db
     .prepare(
-      `INSERT INTO exercise_template_mappings (user_id, program_template_id, hevy_template_id, is_custom)
-       VALUES (?, ?, ?, ?)
+      `INSERT INTO exercise_template_mappings (user_id, program_template_id, hevy_template_id, is_custom, program_id)
+       VALUES (?, ?, ?, ?, ?)
        ON CONFLICT(user_id, program_template_id) DO UPDATE SET
          hevy_template_id = excluded.hevy_template_id,
-         is_custom = excluded.is_custom`
+         is_custom = excluded.is_custom,
+         program_id = excluded.program_id`
     )
-    .bind(mapping.user_id, mapping.program_template_id, mapping.hevy_template_id, mapping.is_custom)
+    .bind(mapping.user_id, mapping.program_template_id, mapping.hevy_template_id, mapping.is_custom, mapping.program_id ?? null)
     .run();
 }
 
 export async function getRoutineMappings(
   db: D1Database,
-  userId: string
+  userId: string,
+  programId?: number
 ): Promise<RoutineMappingRow[]> {
-  const result = await db
-    .prepare("SELECT * FROM routine_mappings WHERE user_id = ?")
-    .bind(userId)
-    .all<RoutineMappingRow>();
+  const result = programId != null
+    ? await db
+        .prepare("SELECT * FROM routine_mappings WHERE user_id = ? AND program_id = ?")
+        .bind(userId, programId)
+        .all<RoutineMappingRow>()
+    : await db
+        .prepare("SELECT * FROM routine_mappings WHERE user_id = ?")
+        .bind(userId)
+        .all<RoutineMappingRow>();
   return result.results;
 }
 
@@ -162,12 +181,13 @@ export async function upsertRoutineMapping(
 ): Promise<void> {
   await db
     .prepare(
-      `INSERT INTO routine_mappings (user_id, program_routine_id, hevy_routine_id)
-       VALUES (?, ?, ?)
+      `INSERT INTO routine_mappings (user_id, program_routine_id, hevy_routine_id, program_id)
+       VALUES (?, ?, ?, ?)
        ON CONFLICT(user_id, program_routine_id) DO UPDATE SET
-         hevy_routine_id = excluded.hevy_routine_id`
+         hevy_routine_id = excluded.hevy_routine_id,
+         program_id = excluded.program_id`
     )
-    .bind(mapping.user_id, mapping.program_routine_id, mapping.hevy_routine_id)
+    .bind(mapping.user_id, mapping.program_routine_id, mapping.hevy_routine_id, mapping.program_id ?? null)
     .run();
 }
 
@@ -273,11 +293,47 @@ export async function getUserByWebhookToken(
     .first<UserRow>();
 }
 
-/** Clear pending queue items and all mappings in a single batch (preserve completed history) */
-export async function clearPendingStateForUser(db: D1Database, userId: string): Promise<void> {
+/** Clear pending queue items and all mappings in a single batch (preserve completed history).
+ * When programId is provided, only clears data for that program. */
+export async function clearPendingStateForUser(db: D1Database, userId: string, programId?: number): Promise<void> {
+  if (programId != null) {
+    await db.batch([
+      db.prepare("DELETE FROM queue_items WHERE user_id = ? AND program_id = ? AND status = 'pending'").bind(userId, programId),
+      db.prepare("DELETE FROM exercise_template_mappings WHERE user_id = ? AND program_id = ?").bind(userId, programId),
+      db.prepare("DELETE FROM routine_mappings WHERE user_id = ? AND program_id = ?").bind(userId, programId),
+    ]);
+  } else {
+    await db.batch([
+      db.prepare("DELETE FROM queue_items WHERE user_id = ? AND status = 'pending'").bind(userId),
+      db.prepare("DELETE FROM exercise_template_mappings WHERE user_id = ?").bind(userId),
+      db.prepare("DELETE FROM routine_mappings WHERE user_id = ?").bind(userId),
+    ]);
+  }
+}
+
+/** Return all programs for a user, ordered by creation date descending. */
+export async function getPrograms(db: D1Database, userId: string): Promise<ProgramRow[]> {
+  const result = await db
+    .prepare("SELECT * FROM programs WHERE user_id = ? ORDER BY created_at DESC")
+    .bind(userId)
+    .all<ProgramRow>();
+  return result.results;
+}
+
+/** Deactivate all programs for user, then activate the specified one. */
+export async function setActiveProgram(db: D1Database, userId: string, programId: number): Promise<void> {
   await db.batch([
-    db.prepare("DELETE FROM queue_items WHERE user_id = ? AND status = 'pending'").bind(userId),
-    db.prepare("DELETE FROM exercise_template_mappings WHERE user_id = ?").bind(userId),
-    db.prepare("DELETE FROM routine_mappings WHERE user_id = ?").bind(userId),
+    db.prepare("UPDATE programs SET is_active = 0 WHERE user_id = ?").bind(userId),
+    db.prepare("UPDATE programs SET is_active = 1 WHERE id = ? AND user_id = ?").bind(programId, userId),
+  ]);
+}
+
+/** Delete a program and its associated queue items and mappings. */
+export async function deleteProgram(db: D1Database, userId: string, programId: number): Promise<void> {
+  await db.batch([
+    db.prepare("DELETE FROM queue_items WHERE user_id = ? AND program_id = ?").bind(userId, programId),
+    db.prepare("DELETE FROM exercise_template_mappings WHERE user_id = ? AND program_id = ?").bind(userId, programId),
+    db.prepare("DELETE FROM routine_mappings WHERE user_id = ? AND program_id = ?").bind(userId, programId),
+    db.prepare("DELETE FROM programs WHERE id = ? AND user_id = ?").bind(programId, userId),
   ]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface QueueItemRow {
   readonly hevy_routine_id: string | null;
   readonly hevy_workout_id: string | null;
   readonly hevy_workout_data: string | null;
+  readonly program_id: number | null;
 }
 
 export interface ExerciseTemplateMappingRow {
@@ -33,12 +34,14 @@ export interface ExerciseTemplateMappingRow {
   readonly program_template_id: string;
   readonly hevy_template_id: string;
   readonly is_custom: number;
+  readonly program_id: number | null;
 }
 
 export interface RoutineMappingRow {
   readonly user_id: string;
   readonly program_routine_id: string;
   readonly hevy_routine_id: string;
+  readonly program_id: number | null;
 }
 
 export interface ProgramRow {

--- a/test/domain/hevy-sync.test.ts
+++ b/test/domain/hevy-sync.test.ts
@@ -14,8 +14,8 @@ describe("buildRoutinePayload", () => {
       ],
     };
     const mappings: ExerciseTemplateMappingRow[] = [
-      { user_id: "u", program_template_id: "dead-hangs", hevy_template_id: "hevy-1", is_custom: 0 },
-      { user_id: "u", program_template_id: "scapular-pushups", hevy_template_id: "hevy-2", is_custom: 0 },
+      { user_id: "u", program_template_id: "dead-hangs", hevy_template_id: "hevy-1", is_custom: 0, program_id: null },
+      { user_id: "u", program_template_id: "scapular-pushups", hevy_template_id: "hevy-2", is_custom: 0, program_id: null },
     ];
     const result = buildRoutinePayload(routine, mappings);
     expect(result.title).toBe("Routine A");
@@ -33,7 +33,7 @@ describe("buildRoutinePayload", () => {
       ],
     };
     const mappings: ExerciseTemplateMappingRow[] = [
-      { user_id: "u", program_template_id: "dead-hangs", hevy_template_id: "hevy-1", is_custom: 0 },
+      { user_id: "u", program_template_id: "dead-hangs", hevy_template_id: "hevy-1", is_custom: 0, program_id: null },
     ];
     const result = buildRoutinePayload(routine, mappings);
     expect(result.unmapped).toEqual(["unknown-exercise"]);
@@ -43,8 +43,8 @@ describe("buildRoutinePayload", () => {
 describe("matchCompletions", () => {
   it("matches workouts to queue items by routine ID", () => {
     const items = [
-      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "pending" as const, completed_date: null, hevy_routine_id: "r-1", hevy_workout_id: null, hevy_workout_data: null },
-      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending" as const, completed_date: null, hevy_routine_id: "r-2", hevy_workout_id: null, hevy_workout_data: null },
+      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "pending" as const, completed_date: null, hevy_routine_id: "r-1", hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending" as const, completed_date: null, hevy_routine_id: "r-2", hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
     const workouts = [
       { id: "w-1", short_id: "s1", title: "Routine A", start_time: "2026-03-21T08:00:00Z", end_time: "2026-03-21T08:30:00Z", exercises: [] },

--- a/test/domain/queue.test.ts
+++ b/test/domain/queue.test.ts
@@ -47,9 +47,9 @@ describe("generatePlaylist", () => {
 describe("getNextRoutine", () => {
   it("returns the first pending item", () => {
     const items: QueueItemRow[] = [
-      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "completed", completed_date: "2026-03-20", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
+      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "completed", completed_date: "2026-03-20", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
     const next = getNextRoutine(items);
     expect(next?.routine_id).toBe("b");
@@ -57,7 +57,7 @@ describe("getNextRoutine", () => {
 
   it("returns null when all items are completed", () => {
     const items: QueueItemRow[] = [
-      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "completed", completed_date: "2026-03-20", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
+      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "completed", completed_date: "2026-03-20", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
     expect(getNextRoutine(items)).toBeNull();
   });
@@ -66,9 +66,9 @@ describe("getNextRoutine", () => {
 describe("getCompletedRoutines", () => {
   it("returns only sessions completed today", () => {
     const items: QueueItemRow[] = [
-      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "completed", completed_date: "2026-03-20", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "completed", completed_date: "2026-03-21", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
+      { id: 1, user_id: "u", routine_id: "a", position: 0, status: "completed", completed_date: "2026-03-20", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "completed", completed_date: "2026-03-21", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
     const completed = getCompletedRoutines(items, "2026-03-21");
     expect(completed).toHaveLength(1);

--- a/test/domain/reflow.test.ts
+++ b/test/domain/reflow.test.ts
@@ -27,9 +27,9 @@ const template: WeekTemplate = {
 describe("computeUpcoming", () => {
   it("interleaves spacer days between main routines based on template rhythm", () => {
     const pending: QueueItemRow[] = [
-      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 4, user_id: "u", routine_id: "recovery", position: 3, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 4, user_id: "u", routine_id: "recovery", position: 3, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
 
     const upcoming = computeUpcoming(pending, template, routines, 5);
@@ -41,8 +41,8 @@ describe("computeUpcoming", () => {
 
   it("derives spacer title from the daily routine's title", () => {
     const pending: QueueItemRow[] = [
-      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
 
     const upcoming = computeUpcoming(pending, template, routines, 5);
@@ -59,8 +59,8 @@ describe("computeUpcoming", () => {
       { id: "recovery", title: "Recovery", exercises: [] },
     ];
     const pending: QueueItemRow[] = [
-      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
-      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null },
+      { id: 2, user_id: "u", routine_id: "b", position: 1, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 3, user_id: "u", routine_id: "c", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
 
     const upcoming = computeUpcoming(pending, template, noDaily, 5);
@@ -72,7 +72,7 @@ describe("computeUpcoming", () => {
     const pending: QueueItemRow[] = Array.from({ length: 10 }, (_, i) => ({
       id: i, user_id: "u", routine_id: "a", position: i,
       status: "pending" as const, completed_date: null,
-      hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null,
+      hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null,
     }));
     const upcoming = computeUpcoming(pending, template, routines, 3);
     const sessionCount = upcoming.filter((u) => u.type === "routine").length;


### PR DESCRIPTION
## Summary
- Add `program_id` column to `queue_items`, `exercise_template_mappings`, `routine_mappings` with backfill migration
- Scope all queue and mapping queries by `program_id`
- `loadProgram` returns `{ program, programId }` for query scoping
- Program Library section on Program page (list all, switch, delete)
- New routes: `POST /api/switch-program/:id`, `POST /api/delete-program/:id`
- `activateProgram` passes `programId` through all operations
- Guards against deleting the active program

## Test plan
- [x] All 56 tests pass
- [ ] Upload two programs → both appear in library
- [ ] Switch between → Today page shows correct queue
- [ ] Switch back → progress preserved
- [ ] Delete inactive program → removed with queue/mappings
- [ ] Cannot delete active program

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)