### PR TITLE
Fix sync window burying workouts + add skip tracking

### DIFF
--- a/src/domain/queue.ts
+++ b/src/domain/queue.ts
@@ -41,6 +41,30 @@ export function getNextRoutine(items: QueueItemRow[]): QueueItemRow | null {
   return sorted.find((item) => item.status === "pending") ?? null;
 }
 
+/**
+ * When a queue item completes out of order, any still-pending items ahead
+ * of it in the queue are stuck — the user moved past them. Mark them
+ * skipped so getNextRoutine advances past them instead of showing them
+ * forever.
+ */
+export function computeSkippedItemIds(
+  items: Pick<QueueItemRow, "id" | "position" | "status">[],
+  completedItemIds: number[]
+): number[] {
+  if (completedItemIds.length === 0) return [];
+
+  const completedSet = new Set(completedItemIds);
+  const completedPositions = items
+    .filter((item) => completedSet.has(item.id))
+    .map((item) => item.position);
+  if (completedPositions.length === 0) return [];
+
+  const maxCompletedPosition = Math.max(...completedPositions);
+  return items
+    .filter((item) => item.status === "pending" && !completedSet.has(item.id) && item.position < maxCompletedPosition)
+    .map((item) => item.id);
+}
+
 export function getCompletedRoutines(items: QueueItemRow[], today: string): QueueItemRow[] {
   return items
     .filter((item) => item.status === "completed" && item.completed_date === today)

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -1,7 +1,39 @@
-import { loadProgram, getQueueItems, batchMarkQueueItemsCompleted, updateDailyCompleted, updateLastSyncAt } from "../storage/queries";
+import { loadProgram, getQueueItems, batchMarkQueueItemsCompleted, batchMarkQueueItemsSkipped, updateDailyCompleted, updateLastSyncAt } from "../storage/queries";
 import { matchCompletions } from "../domain/hevy-sync";
-import { HevyClient } from "../hevy/client";
+import { computeSkippedItemIds } from "../domain/queue";
+import { HevyClient, type HevyWorkout } from "../hevy/client";
 import { todayString, toLocalDate } from "../utils/date";
+
+const SYNC_MAX_PAGES = 10;
+const SYNC_PAGE_SIZE = 20;
+
+/**
+ * Fetch recent workouts, paging back until every title we're looking for has
+ * been found (or the page cap is hit). A single page-of-5 fetch isn't deep
+ * enough once several daily-routine workouts pile up between a session and
+ * the next sync — the session's workout falls off the window and never
+ * matches. Bounded to SYNC_MAX_PAGES so a stuck lookup can't page forever.
+ */
+export async function fetchWorkoutsCoveringTitles(
+  client: Pick<HevyClient, "getRecentWorkouts">,
+  titlesToFind: Set<string>,
+  usedWorkoutIds: Set<string>
+): Promise<HevyWorkout[]> {
+  const all: HevyWorkout[] = [];
+  const remaining = new Set(titlesToFind);
+
+  for (let page = 1; page <= SYNC_MAX_PAGES && remaining.size > 0; page++) {
+    const batch = await client.getRecentWorkouts(page, SYNC_PAGE_SIZE);
+    if (batch.length === 0) break;
+    all.push(...batch);
+    for (const w of batch) {
+      if (!usedWorkoutIds.has(w.id)) remaining.delete(w.title);
+    }
+    if (batch.length < SYNC_PAGE_SIZE) break;
+  }
+
+  return all;
+}
 
 /**
  * Core sync logic — fetch recent Hevy workouts, match to pending queue items,
@@ -13,29 +45,36 @@ export async function performSync(db: D1Database, userId: string, apiKey: string
   const routineMap = new Map(program.routines.map((r) => [r.id, r]));
   const client = new HevyClient(apiKey);
 
-  const [workouts, items] = await Promise.all([
-    client.getRecentWorkouts(),
-    getQueueItems(db, userId, programId),
-  ]);
+  const items = await getQueueItems(db, userId, programId);
 
   // Skip workouts already matched to a completed queue item
-  const usedWorkoutIds = new Set(
-    items.filter((i) => i.hevy_workout_id).map((i) => i.hevy_workout_id)
+  const usedWorkoutIds = new Set<string>(
+    items.filter((i): i is typeof i & { hevy_workout_id: string } => i.hevy_workout_id != null).map((i) => i.hevy_workout_id)
   );
-  const newWorkouts = workouts.filter((w) => !usedWorkoutIds.has(w.id));
 
-  const pendingItems = items.filter((i) => i.status === "pending" && i.hevy_routine_id);
+  // Matchable items include "skipped" ones too, so a late-arriving workout
+  // can still retroactively complete an item the user actually did.
+  const matchableItems = items.filter(
+    (i) => (i.status === "pending" || i.status === "skipped") && i.hevy_routine_id
+  );
 
   const nameToRoutineId = new Map<string, string>();
-  for (const item of pendingItems) {
+  for (const item of matchableItems) {
     const routine = routineMap.get(item.routine_id);
     if (routine && item.hevy_routine_id) {
       nameToRoutineId.set(routine.title, item.hevy_routine_id);
     }
   }
 
+  const dailyRoutine = program.routines.find((r) => r.isDaily);
+  const titlesToFind = new Set(nameToRoutineId.keys());
+  if (dailyRoutine) titlesToFind.add(dailyRoutine.title);
+
+  const workouts = await fetchWorkoutsCoveringTitles(client, titlesToFind, usedWorkoutIds);
+  const newWorkouts = workouts.filter((w) => !usedWorkoutIds.has(w.id));
+
   const matches = matchCompletions(
-    pendingItems,
+    matchableItems,
     newWorkouts,
     (w) => nameToRoutineId.get(w.title) ?? null
   );
@@ -63,8 +102,12 @@ export async function performSync(db: D1Database, userId: string, apiKey: string
     })
   );
 
+  // A completion further down the queue means the user moved past whatever
+  // was still pending ahead of it — mark those skipped so "Next" advances.
+  const skippedIds = computeSkippedItemIds(items, matches.map((m) => m.queueItemId));
+  await batchMarkQueueItemsSkipped(db, skippedIds);
+
   // Check for daily routine completion (use workout date, not sync date)
-  const dailyRoutine = program.routines.find((r) => r.isDaily);
   if (dailyRoutine) {
     const dailyWorkout = workouts.find((w) => w.title === dailyRoutine.title);
     if (dailyWorkout) {

--- a/src/storage/queries.ts
+++ b/src/storage/queries.ts
@@ -98,6 +98,16 @@ export async function batchMarkQueueItemsCompleted(
   );
 }
 
+/** Batch-mark multiple queue items as skipped (out of order — user moved past them) */
+export async function batchMarkQueueItemsSkipped(db: D1Database, itemIds: number[]): Promise<void> {
+  if (itemIds.length === 0) return;
+  await db.batch(
+    itemIds.map((itemId) =>
+      db.prepare("UPDATE queue_items SET status = 'skipped' WHERE id = ?").bind(itemId)
+    )
+  );
+}
+
 export async function markQueueItemCompletedForUser(
   db: D1Database,
   itemId: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface QueueItemRow {
   readonly user_id: string;
   readonly routine_id: string;
   readonly position: number;
-  readonly status: "pending" | "completed";
+  readonly status: "pending" | "completed" | "skipped";
   readonly completed_date: string | null;
   readonly hevy_routine_id: string | null;
   readonly hevy_workout_id: string | null;

--- a/test/domain/queue.test.ts
+++ b/test/domain/queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generatePlaylist, getNextRoutine, getCompletedRoutines } from "../../src/domain/queue";
+import { generatePlaylist, getNextRoutine, getCompletedRoutines, computeSkippedItemIds } from "../../src/domain/queue";
 import type { WeekTemplate, Routine, QueueItemRow } from "../../src/types";
 
 const routines: Routine[] = [
@@ -60,6 +60,57 @@ describe("getNextRoutine", () => {
       { id: 1, user_id: "u", routine_id: "a", position: 0, status: "completed", completed_date: "2026-03-20", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
     ];
     expect(getNextRoutine(items)).toBeNull();
+  });
+
+  it("skips over items marked skipped", () => {
+    const items: QueueItemRow[] = [
+      { id: 1, user_id: "u", routine_id: "c", position: 0, status: "skipped", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 2, user_id: "u", routine_id: "d", position: 1, status: "completed", completed_date: "2026-03-21", hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+      { id: 3, user_id: "u", routine_id: "e", position: 2, status: "pending", completed_date: null, hevy_routine_id: null, hevy_workout_id: null, hevy_workout_data: null, program_id: null },
+    ];
+    const next = getNextRoutine(items);
+    expect(next?.routine_id).toBe("e");
+  });
+});
+
+describe("computeSkippedItemIds", () => {
+  it("marks earlier pending items skipped when a later item completes", () => {
+    const items = [
+      { id: 1, position: 0, status: "pending" as const },
+      { id: 2, position: 1, status: "pending" as const },
+      { id: 3, position: 2, status: "pending" as const },
+      { id: 4, position: 3, status: "pending" as const },
+    ];
+    // user completed item 3 (position 2), skipping items 1 and 2
+    const skipped = computeSkippedItemIds(items, [3]);
+    expect(skipped.sort()).toEqual([1, 2]);
+  });
+
+  it("returns nothing when the completed item is already the earliest pending", () => {
+    const items = [
+      { id: 1, position: 0, status: "pending" as const },
+      { id: 2, position: 1, status: "pending" as const },
+    ];
+    expect(computeSkippedItemIds(items, [1])).toEqual([]);
+  });
+
+  it("returns nothing when no items were completed", () => {
+    const items = [
+      { id: 1, position: 0, status: "pending" as const },
+    ];
+    expect(computeSkippedItemIds(items, [])).toEqual([]);
+  });
+
+  it("does not re-skip items that are already completed or skipped", () => {
+    const items = [
+      { id: 1, position: 0, status: "completed" as const },
+      { id: 2, position: 1, status: "skipped" as const },
+      { id: 3, position: 2, status: "pending" as const },
+      { id: 4, position: 3, status: "pending" as const },
+    ];
+    // item 4 (position 3) completes; only item 3 (still pending) should skip
+    const skipped = computeSkippedItemIds(items, [4]);
+    expect(skipped).toEqual([3]);
   });
 });
 

--- a/test/domain/sync-fetch.test.ts
+++ b/test/domain/sync-fetch.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { fetchWorkoutsCoveringTitles } from "../../src/services/sync";
+import type { HevyWorkout } from "../../src/hevy/client";
+
+function workout(id: string, title: string): HevyWorkout {
+  return { id, short_id: id, title, start_time: "2026-03-01T08:00:00Z", end_time: "2026-03-01T08:30:00Z", exercises: [] };
+}
+
+/**
+ * Fake paged client honoring the real Hevy API contract: each page returns
+ * up to `pageSize` items; a page shorter than `pageSize` signals the end.
+ */
+function fakeClient(allWorkoutsNewestFirst: HevyWorkout[]) {
+  return {
+    async getRecentWorkouts(page = 1, pageSize = 5) {
+      const start = (page - 1) * pageSize;
+      return allWorkoutsNewestFirst.slice(start, start + pageSize);
+    },
+  };
+}
+
+describe("fetchWorkoutsCoveringTitles", () => {
+  it("finds a title on page 1 without paging further", async () => {
+    let pagesFetched = 0;
+    const client = {
+      async getRecentWorkouts(page = 1) {
+        pagesFetched++;
+        return [workout(`w${page}`, "Session B")];
+      },
+    };
+    await fetchWorkoutsCoveringTitles(client, new Set(["Session B"]), new Set());
+    expect(pagesFetched).toBe(1);
+  });
+
+  it("pages back to find a title buried behind newer workouts (the CARs-burial bug)", async () => {
+    // Session A was logged days ago; 40+ Daily CARs + Session B entries since
+    // then push it well past a single page-of-5 (or page-of-20) fetch.
+    const filler = Array.from({ length: 40 }, (_, i) => workout(`cars-${i}`, "Daily CARs"));
+    const allWorkouts = [workout("session-b", "Session B"), ...filler, workout("session-a", "Session A")];
+    const client = fakeClient(allWorkouts);
+    const result = await fetchWorkoutsCoveringTitles(client, new Set(["Session A", "Session B"]), new Set());
+    expect(result.map((w) => w.id)).toContain("session-a");
+  });
+
+  it("stops paging once every title is found", async () => {
+    let pagesFetched = 0;
+    const client = {
+      async getRecentWorkouts(page = 1) {
+        pagesFetched++;
+        if (page === 1) return [workout("w1", "Session A")];
+        return [workout(`w${page}`, "Daily CARs")];
+      },
+    };
+    await fetchWorkoutsCoveringTitles(client, new Set(["Session A"]), new Set());
+    expect(pagesFetched).toBe(1);
+  });
+
+  it("does not page forever when a title never shows up (bounded loop)", async () => {
+    let pagesFetched = 0;
+    const client = {
+      async getRecentWorkouts(page = 1, pageSize = 20) {
+        pagesFetched++;
+        return Array.from({ length: pageSize }, (_, i) => workout(`w${page}-${i}`, "Unrelated"));
+      },
+    };
+    await fetchWorkoutsCoveringTitles(client, new Set(["Never Logged"]), new Set());
+    expect(pagesFetched).toBe(10);
+  });
+
+  it("ignores already-used workout IDs when checking whether a title was found", async () => {
+    const filler = Array.from({ length: 20 }, (_, i) => workout(`cars-${i}`, "Daily CARs"));
+    const client = fakeClient([workout("used", "Session A"), ...filler, workout("fresh", "Session A")]);
+    const result = await fetchWorkoutsCoveringTitles(client, new Set(["Session A"]), new Set(["used"]));
+    expect(result.map((w) => w.id)).toContain("fresh");
+  });
+});


### PR DESCRIPTION
## Summary
- Sync only fetched page 1 / 5 recent Hevy workouts. Daily CARs entries logged after a session pushed it off that window, so it never matched and stayed "pending" forever. `fetchWorkoutsCoveringTitles` now pages back (bounded, capped) until every pending routine title is found.
- `getNextRoutine` was pure position-sort with no awareness of what was actually completed. Skipping session C for D left C shown as "next" forever. `computeSkippedItemIds` now marks earlier still-pending items skipped when a later one completes.

## Test plan
- [x] `npx vitest run` — 111/111 passing
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj6tYLm6TV3KuBrE44YjqN